### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM debian:8
 MAINTAINER VCA Technology <developers@vcatechnology.com>
 
 # Build-time metadata as defined at http://label-schema.org


### PR DESCRIPTION
Use Debian 8 as base image

For now we should keep using Debian 8 until we can test that Debian 9 is not breaking the build.